### PR TITLE
Wrap result if multiple is False

### DIFF
--- a/selpages/element.py
+++ b/selpages/element.py
@@ -55,7 +55,7 @@ class Element(object):
             try:
                 result = f(*locator)
                 if self._wrapper:
-                    result = [self._wrapper(e) for e in result] if self.multiple else self._wrapper(e)
+                    result = [self._wrapper(e) for e in result] if self.multiple else self._wrapper(result)
                 return result
             except NoSuchElementException:
                 pass


### PR DESCRIPTION
If an Element descriptor does not represent multiple elements (i.e.,
multiple=False), then wrap the found element in result.

Fixes #2.